### PR TITLE
Support for MidiBase.is_port_open() through RtMidi.isPortOpen

### DIFF
--- a/src/_rtmidi.pyx
+++ b/src/_rtmidi.pyx
@@ -171,6 +171,7 @@ cdef extern from "RtMidi.h":
         void openVirtualPort(string portName) except +
         void closePort()
         void setErrorCallback(RtMidiErrorCallback callback, void *userData)
+        bool isPortOpen()
 
     cdef cppclass RtMidiIn(RtMidi):
         Api RtMidiIn() except +
@@ -472,6 +473,11 @@ cdef class MidiBase:
 
         """
         self.baseptr().setErrorCallback(NULL, NULL)
+
+    def is_port_open(self):
+        """Returns true if a port is open and false if not.
+        """
+        return self.baseptr().isPortOpen()
 
 
 cdef class MidiIn(MidiBase):

--- a/src/_rtmidi.pyx
+++ b/src/_rtmidi.pyx
@@ -171,7 +171,6 @@ cdef extern from "RtMidi.h":
         void openVirtualPort(string portName) except +
         void closePort()
         void setErrorCallback(RtMidiErrorCallback callback, void *userData)
-        bool isPortOpen()
 
     cdef cppclass RtMidiIn(RtMidi):
         Api RtMidiIn() except +
@@ -477,7 +476,7 @@ cdef class MidiBase:
     def is_port_open(self):
         """Returns true if a port is open and false if not.
         """
-        return self.baseptr().isPortOpen()
+        return self._port is not None
 
 
 cdef class MidiIn(MidiBase):


### PR DESCRIPTION
I didn't find the support for the isPortOpen call, so I added to the MidiBase class.
Unfortunally, rtmidi does not support notifications for external connections/disconnections, so if the port is connected or disconnected from another program (such as aconnect on linux), the method will answer according to its internal "static" state, which might not correspond to the actual state.