### PR TITLE
Add support for automatically building Windows / OSX wheels using AppVeyor / Travis CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,36 @@
+skip_non_tags: true
+
+environment:
+
+  matrix:
+
+    - PYTHON: Python27
+    - PYTHON: Python27-x64
+    - PYTHON: Python35
+    - PYTHON: Python35-x64
+    - PYTHON: Python36
+    - PYTHON: Python36-x64
+    - PYTHON: Python37
+    - PYTHON: Python37-x64
+
+# To clear the cache, see https://ci.appveyor.com/api-keys for the token and use:
+# wget --header="Authorization: Bearer $TOKEN" --method DELETE https://ci.appveyor.com/api/projects/$USER/$PROJECT/buildcache
+cache:
+  - '%LOCALAPPDATA%\pip\Cache'
+
+clone_depth: 1
+
+install:
+  - "SET PATH=C:\\%PYTHON%;C:\\%PYTHON%\\Scripts;%PATH%"
+  - python --version
+  - python -m pip --disable-pip-version-check install -U pip setuptools wheel
+  - python -m pip install -U Cython twine"
+  - python -m pip freeze --all
+
+build_script:
+  - ps: $env:SOURCE_DATE_EPOCH = (git log -1 --date=unix --format='format:%ct' rtmidi/release.py) | Out-String
+  - "python setup.py release"
+
+test: off
+
+on_success: "if [%APPVEYOR_REPO_TAG%]==[true] twine upload dist\\*.whl"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,54 @@
+if: tag IS present
+
+language: generic
+os: osx
+osx_image: xcode8
+
+cache:
+  directories:
+    - /Users/travis/Library/Caches/pip
+
+matrix:
+  include:
+    - name: Python 2.7
+      env:
+        PYTHON: python2.7
+        PYTHON_INSTALLER_URL: https://www.python.org/ftp/python/2.7.15/python-2.7.15-macosx10.6.pkg
+        PYTHON_INSTALLER_MD5: 9ac8c85150147f679f213addd1e7d96e
+        PATH: /Users/travis/Library/Python/2.7/bin:$PATH
+    - name: Python 3.6
+      env:
+        PYTHON: python3.6
+        PYTHON_INSTALLER_URL: https://www.python.org/ftp/python/3.6.6/python-3.6.6-macosx10.6.pkg
+        PYTHON_INSTALLER_MD5: c58267cab96f6d291d332a2b163edd33
+        PATH: /Users/travis/Library/Python/3.6/bin:$PATH
+    - name: Python 3.7
+      env:
+        PYTHON: python3.7
+        PYTHON_INSTALLER_URL: https://www.python.org/ftp/python/3.7.0/python-3.7.0-macosx10.6.pkg
+        PYTHON_INSTALLER_MD5: ca3eb84092d0ff6d02e42f63a734338e
+        PATH: /Users/travis/Library/Python/3.7/bin:$PATH
+
+git:
+  depth: 1
+
+install:
+  - wget -O python.pkg "$PYTHON_INSTALLER_URL"
+  - test "$(md5 -q python.pkg)" = $PYTHON_INSTALLER_MD5
+  - sudo installer -pkg python.pkg -target /
+  - $PYTHON --version
+  - $PYTHON -m pip --disable-pip-version-check install --user -U pip setuptools wheel
+  - $PYTHON -m pip install --user -U Cython twine
+  - $PYTHON -m pip freeze --all
+
+script:
+  - export SOURCE_DATE_EPOCH="$(git log -1 --date=unix --format='format:%ct' rtmidi/release.py)"
+  - $PYTHON setup.py release
+
+deploy:
+  provider: script
+  skip_cleanup: true
+  script: $PYTHON -m twine upload dist/*.whl
+  on:
+    all_branches: true
+    tag: true

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ include *.rst
 include src/*.cpp src/*.h src/*.pyx
 
 exclude .appveyor.yml
+exclude .travis.yml
 exclude *.rst.in
 exclude deploy.sh
 exclude *.sh

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ include tox.ini
 include *.rst
 include src/*.cpp src/*.h src/*.pyx
 
+exclude .appveyor.yml
 exclude *.rst.in
 exclude deploy.sh
 exclude *.sh


### PR DESCRIPTION
Build wheels for:
- Windows: 32bits and 64bits variants for Python 2.7, 3.5, 3.6, and 3.7
- macOS: Python 2.7, 3.6, and 3.7

Those are automatically uploaded to PyPI.

`TWINE_USERNAME` and `TWINE_PASSWORD` must be set in each project settings (don't forget to toggle encryption for `TWINE_PASSWORD` on AppVeyor!).

The builds are started on tag only (but the tag name itself does not matter): at first I added support for running the tests, but most of them fail because of the lack of MIDI devices: `RuntimeError: MidiOutCore::openPort: no MIDI output destinations found!`.
