### PR TITLE
Allow deletion of internal C++ RtMidiIn/Out instance

### DIFF
--- a/src/_rtmidi.pyx
+++ b/src/_rtmidi.pyx
@@ -432,9 +432,9 @@ def _default_error_handler(etype, msg, data=None):
 
 
 cdef class MidiBase:
-    cdef object _deleted
     cdef object _port
     cdef object _error_callback
+    cdef object _deleted
 
     cdef RtMidi* baseptr(self):
         return NULL
@@ -864,6 +864,10 @@ cdef class MidiIn(MidiBase):
             del self.thisptr
             self._deleted = True
 
+    @property
+    def is_deleted(self):
+        return self._deleted
+
     def cancel_callback(self):
         """Remove the registered callback function for MIDI input.
 
@@ -1021,6 +1025,7 @@ cdef class MidiOut(MidiBase):
 
         self.set_error_callback(_default_error_handler)
         self._port = None
+        self._deleted = False
 
     def __dealloc__(self):
         """De-allocate pointer to C++ class instance."""
@@ -1047,6 +1052,10 @@ cdef class MidiOut(MidiBase):
         if not self._deleted:
             del self.thisptr
             self._deleted = True
+
+    @property
+    def is_deleted(self):
+        return self._deleted
 
     def get_current_api(self):
         """Return the low-level MIDI backend API used by this instance.

--- a/src/_rtmidi.pyx
+++ b/src/_rtmidi.pyx
@@ -432,6 +432,7 @@ def _default_error_handler(etype, msg, data=None):
 
 
 cdef class MidiBase:
+    cdef object _deleted
     cdef object _port
     cdef object _error_callback
 
@@ -821,6 +822,7 @@ cdef class MidiIn(MidiBase):
         self.set_error_callback(_default_error_handler)
         self._callback = None
         self._port = None
+        self._deleted = False
 
     def get_current_api(self):
         """Return the low-level MIDI backend API used by this instance.
@@ -838,7 +840,29 @@ cdef class MidiIn(MidiBase):
 
     def __dealloc__(self):
         """De-allocate pointer to C++ class instance."""
-        del self.thisptr
+        if hasattr(self, "thisptr"):
+            del self.thisptr
+
+    def delete(self):
+        """De-allocate pointer to C++ class instance.
+
+        .. warning:: the instance **must not** be used anymore after calling
+            this method, otherwise the program will crash with a segmentation
+            fault!
+
+            The reason this potentially dangerous method exists is that in
+            some cases it is desirable to destroy the internal ``RtMidiIn``
+            C++ class instance with immediate effect, thereby closing the
+            backend MIDI API client and all the ports it opened. By merely
+            using ``del`` on the ``rtmidi.MidiIn`` Python instance, the
+            destruction of the C++ instance may be delayed for an arbitrary
+            amount of time, until the Python garbage collector cleans up the
+            instance.
+
+        """
+        if not self._deleted:
+            del self.thisptr
+            self._deleted = True
 
     def cancel_callback(self):
         """Remove the registered callback function for MIDI input.
@@ -1000,7 +1024,29 @@ cdef class MidiOut(MidiBase):
 
     def __dealloc__(self):
         """De-allocate pointer to C++ class instance."""
-        del self.thisptr
+        if hasattr(self, "thisptr"):
+            del self.thisptr
+
+    def delete(self):
+        """De-allocate pointer to C++ class instance.
+
+        .. warning:: the instance **must not** be used anymore after calling
+            this method, otherwise the program will crash with a segmentation
+            fault!
+
+            The reason this potentially dangerous method exists is that in
+            some cases it is desirable to destroy the internal ``RtMidiOut``
+            C++ class instance with immediate effect, thereby closing the
+            backend MIDI API client and all the ports it opened. By merely
+            using ``del`` on the ``rtmidi.MidiOut`` Python instance, the
+            destruction of the C++ instance may be delayed for an arbitrary
+            amount of time, until the Python garbage collector cleans up the
+            instance.
+
+        """
+        if not self._deleted:
+            del self.thisptr
+            self._deleted = True
 
     def get_current_api(self):
         """Return the low-level MIDI backend API used by this instance.

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Unit tests for the rtmidi module."""
+
+import time
+import unittest
+
+import rtmidi
+
+
+class TestDelete(unittest.TestCase):
+
+    def setUp(self):
+        self.midiout = rtmidi.MidiOut()
+        self.midiin = rtmidi.MidiIn()
+
+    def test_midiin_delete(self):
+        midiin_ports = self.midiin.get_ports()
+        print("Input ports:")
+        print(midiin_ports)
+
+        ports_init = self.midiout.get_ports()
+        print("output ports initially:")
+        print(ports_init)
+
+        if midiin_ports:
+            self.midiin.open_port(0)
+        else:
+            self.midiin.open_virtual_port("My virtual output")
+
+        ports_before = self.midiout.get_ports()
+
+        self.assertEqual(len(ports_before), len(ports_init) + 1)
+        print("Output ports BEFORE deleting MidiIn instance:")
+        print(ports_before)
+
+        self.midiin.delete()
+
+        ports_after = self.midiout.get_ports()
+        print("Output ports AFTER deleting MidiIn instance:")
+        print(ports_after)
+
+        self.assertEqual(set(ports_init), set(ports_after))
+
+    def test_midiout_delete(self):
+        midiout_ports = self.midiout.get_ports()
+        print("Output ports:")
+        print(midiout_ports)
+
+        ports_init = self.midiin.get_ports()
+        print("Input ports initially:")
+        print(ports_init)
+
+        if midiout_ports:
+            self.midiout.open_port(0)
+        else:
+            self.midiout.open_virtual_port("My virtual output")
+
+        ports_before = self.midiin.get_ports()
+
+        self.assertEqual(len(ports_before), len(ports_init) + 1)
+        print("Input ports BEFORE deleting MidiOut instance:")
+        print(ports_before)
+
+        self.midiout.delete()
+
+        ports_after = self.midiin.get_ports()
+        print("Input ports AFTER deleting MidiOut instance:")
+        print(ports_after)
+
+        self.assertEqual(set(ports_init), set(ports_after))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """Unit tests for the rtmidi module."""
 
-import time
+import gc
 import unittest
 
 import rtmidi
@@ -69,6 +69,21 @@ class TestDelete(unittest.TestCase):
         print(ports_after)
 
         self.assertEqual(set(ports_init), set(ports_after))
+
+    def test_double_delete(self):
+        self.assertFalse(self.midiout.is_deleted)
+        self.midiout.delete()
+        self.assertTrue(self.midiout.is_deleted)
+        self.midiout.delete()
+        self.assertTrue(self.midiout.is_deleted)
+
+    def test_del_after_delete(self):
+        self.midiout.delete()
+        self.assertTrue(self.midiout.is_deleted)
+        self.assertTrue(hasattr(self, 'midiout'))
+        del self.midiout
+        gc.collect()
+        self.assertFalse(hasattr(self, 'midiout'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Add 'delete' method.
* Add 'is_deleted' property.

Relates: #60