### PR TITLE
Build wheels using cibuildwheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-python@v2
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.1.2
+        uses: pypa/cibuildwheel@v2.3.0
         # to supply options, put them in 'env', like:
         # env:
         #   CIBW_SOME_OPTION: value
@@ -63,7 +63,7 @@ jobs:
       with:
         platforms: all
 
-    - uses: pypa/cibuildwheel@v2.1.2
+    - uses: pypa/cibuildwheel@v2.3.0
       env:
         CIBW_ARCHS: ${{ matrix.arch }}
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -25,8 +25,9 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-10.15]
+        os: [ubuntu-22.04, windows-2022, macOS-11]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         path: dist/*.tar.gz
-        
+
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -46,3 +46,32 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
+
+  build_arch_wheels:
+    name: linux on ${{ matrix.arch }}
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        arch: [aarch64]
+    steps:
+
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+
+    - uses: docker/setup-qemu-action@v1.2.0
+      with:
+        platforms: all
+
+    - uses: pypa/cibuildwheel@v2.1.2
+      env:
+        CIBW_ARCHS: ${{ matrix.arch }}
+
+    - name: Verify clean directory
+      run: git diff --exit-code
+      shell: bash
+
+    - name: Upload wheels
+      uses: actions/upload-artifact@v2
+      with:
+        path: wheelhouse/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,30 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macOS-10.15]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      # Used to host cibuildwheel
+      - uses: actions/setup-python@v2
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.1.2
+        # to supply options, put them in 'env', like:
+        # env:
+        #   CIBW_SOME_OPTION: value
+
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -48,7 +48,7 @@ jobs:
           path: ./wheelhouse/*.whl
 
   build_arch_wheels:
-    name: linux on ${{ matrix.arch }}
+    name: Build wheels on linux ${{ matrix.arch }}
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -3,6 +3,24 @@ name: Build
 on: [push, pull_request]
 
 jobs:
+  build_sdist:
+    name: Build SDist
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+
+    - name: Build SDist
+      run: pipx run build --sdist
+
+    - name: Check metadata
+      run: pipx run twine check --strict dist/*
+
+    - uses: actions/upload-artifact@v2
+      with:
+        path: dist/*.tar.gz
+        
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+#cibuildwheel output dir
+wheelhouse
+
 # Python bytecode
 *.py[cod]
 __pycache__

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,9 @@ A Python binding for the RtMidi C++ library implemented using Cython.
     :target: https://travis-ci.org/SpotlightKid/python-rtmidi
     :alt: Travis CI status
 
+.. |github actions| image:: https://github.com/SpotlightKid/python-rtmidi/actions/workflows/wheels.yml/badge.svg
+    :target: https://github.com/SpotlightKid/python-rtmidi/actions/workflows/wheels.yml
+    :alt: Github Actions status
 
 Overview
 ========

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,11 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel.linux]
 before-all = "yum install -y alsa-lib-devel alsa-utils || apt-get install -y libasound2-dev libjack-jackd2-dev"
+skip = "*-musllinux*"
 
-[tool.cibuildwheel.overrides]
+[[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"
-before-all = "apk add jack -y"
+before-all = "apk add jack libpthread-stubs alsa-utils alsa-utils-doc alsa-lib alsaconf"
 
 [tool.cibuildwheel.macos]
 archs = "universal2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,6 @@ build-backend = "setuptools.build_meta"
 [tool.cibuildwheel.linux]
 before-all = "yum install -y alsa-lib-devel alsa-utils || apt install -y libasound2-dev libjack-jackd2-dev"
 
+
+[tool.cibuildwheel.macos]
+archs = "universal2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+# Minimum requirements for the build system to execute.
+requires = ["setuptools>=42.0.0", "wheel>=0.34.2", "cython"]  # PEP 508 specifications.
+build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel.linux]
+before-all = "yum install -y alsa-lib-devel alsa-utils || apt install -y libasound2-dev libjack-jackd2-dev"
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,11 @@ requires = ["setuptools>=42.0.0", "wheel>=0.34.2", "cython"]  # PEP 508 specific
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel.linux]
-before-all = "yum install -y alsa-lib-devel alsa-utils || apt install -y libasound2-dev libjack-jackd2-dev"
+before-all = "yum install -y alsa-lib-devel alsa-utils || apt-get install -y libasound2-dev libjack-jackd2-dev"
 
+[tool.cibuildwheel.overrides]
+select = "*-musllinux*"
+before-all = "apk add jack -y"
 
 [tool.cibuildwheel.macos]
 archs = "universal2"

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ author = Christopher Arndt
 author_email = chris@chrisarndt.de
 license = MIT License
 long_description = file: README.rst
+long_description_content_type = text/x-rst
 url = https://github.com/SpotlightKid/python-rtmidi
 download_url = https://pypi.python.org/pypi/python-rtmidi
 repository = https://github.com/SpotlightKid/python-rtmidi.git


### PR DESCRIPTION
This PR adds building wheels using [cibuildwheel](https://github.com/pypa/cibuildwheel/) which simplifies creating wheels and adds support for Linux wheels. It also changes macOS wheels from x86_64 to universal2 (to work on m1 machine). 

I do not found an option to run tests on CI.

Here sample run https://github.com/Czaki/python-rtmidi/actions/runs/1253787788