### PR TITLE
fix macOS binary wheel builds

### DIFF
--- a/.github/workflows/push_to_feat.yml
+++ b/.github/workflows/push_to_feat.yml
@@ -1,0 +1,30 @@
+name: Build and test wheels
+
+on:
+  push:
+    branches:
+      - 'feat/**'
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [macos-latest]
+    steps:
+
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - uses: ilammy/msvc-dev-cmd@v1
+      if: matrix.os == 'windows-latest'
+
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.13
+
+    - uses: actions/upload-artifact@v3
+      with:
+        path: wheelhouse/*.whl

--- a/meson.build
+++ b/meson.build
@@ -60,8 +60,8 @@ elif host_machine.system() == 'darwin'
 
     if host_machine.cpu_family() == 'x86_64' and ARCHFLAGS == '-arch arm64'
         message('Crosscompiling from Intel to Apple Silicon')
-        add_project_arguments('-arch', 'arm64', '--target=arm64-apple-macos', language: ['cpp', 'c'])
-        add_project_link_arguments('-arch', 'arm64', '--target=arm64-apple-macos', language: ['cpp', 'c'])
+        add_project_arguments('-arch', 'arm64', '--target=arm64-apple-darwin', language: ['cpp', 'c'])
+        add_project_link_arguments('-arch', 'arm64', '--target=arm64-apple-darwin', language: ['cpp', 'c'])
     endif
 
     # API

--- a/meson.build
+++ b/meson.build
@@ -55,12 +55,13 @@ elif host_machine.system() == 'darwin'
 
     # Enable cross compilation if host is x86 and target is arm64
     # Meson doesn't have env access support on purpose...
-    cmd = run_command('sh', '-c', 'echo $ARCHFLAGS ')
+    cmd = run_command('sh', '-c', 'echo $ARCHFLAGS ', check: true)
     ARCHFLAGS = cmd.stdout().strip()
+
     if host_machine.cpu_family() == 'x86_64' and ARCHFLAGS == '-arch arm64'
         message('Crosscompiling from Intel to Apple Silicon')
-        add_project_arguments('-arch arm64 --target=arm64-apple-darwin', language: ['cpp', 'c'])
-        add_project_link_arguments('-arch arm64 --target=arm64-apple-darwin', language: ['cpp', 'c'])
+        add_project_arguments('-arch', 'arm64', '--target=arm64-apple-macos', language: ['cpp', 'c'])
+        add_project_link_arguments('-arch', 'arm64', '--target=arm64-apple-macos', language: ['cpp', 'c'])
     endif
 
     # API

--- a/meson.build
+++ b/meson.build
@@ -53,6 +53,16 @@ elif host_machine.system() == 'darwin'
     # Enable c++11 support
     add_project_arguments('-std=c++11', language: ['cpp'])
 
+    # Enable cross compilation if host is x86 and target is arm64
+    # Meson doesn't have env access support on purpose...
+    cmd = run_command('sh', '-c', 'echo $ARCHFLAGS ')
+    ARCHFLAGS = cmd.stdout().strip()
+    if host_machine.cpu_family() == 'x86_64' and ARCHFLAGS == '-arch arm64'
+        message('Crosscompiling from Intel to Apple Silicon')
+        add_project_arguments('-arch arm64 --target=arm64-apple-darwin', language: ['cpp', 'c'])
+        add_project_link_arguments('-arch arm64 --target=arm64-apple-darwin', language: ['cpp', 'c'])
+    endif
+
     # API
     coremidi_dep = dependency(
         'appleframeworks',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,9 +111,6 @@ before-all = [
 build = "cp311-macosx*"
 archs = ["arm64"]
 environment = { ARCHFLAGS="-arch arm64" }
-before-all = [
-    "pipx install ninja",
-]
 
 [tool.cibuildwheel.windows]
 build = "cp3{8,9,10,11}-win*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,9 +105,9 @@ before-all = [
 ]
 
 [tool.cibuildwheel.macos]
-build = "cp3{8,9,10,11}-macosx*"
-archs = ["x86_64", "arm64"]
-environment = { MACOSX_DEPLOYMENT_TARGET = "10.14" }
+build = "cp311-macosx*"
+archs = ["arm64"]
+environment = { ARCHFLAGS="-arch arm64" }
 before-all = [
     "pipx install ninja",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "mesonpep517.buildapi"
 requires = [
     "cython",
     "wheel",
-    "mesonpep517 @ git+https://gitlab.com/SpotlightKid/mesonpep517.git@rtmidi",
+    "mesonpep517 @ git+https://gitlab.com/SpotlightKid/mesonpep517.git@feat/verbose-compile-options",
     "ninja"
 ]
 
@@ -41,10 +41,13 @@ keywords = [
     "music",
     "rtmidi",
 ]
+
+meson-verbose = true
+meson-compile = true
 meson-python-option-name = "python"
 meson-options = [
     "-Dwheel=true",
-    "-Dverbose=false",
+    "-Dverbose=true",
     "--buildtype=plain"
 ]
 


### PR DESCRIPTION
The binary wheels marked as for the arm64 architecture for release 1.5.0/1/2 contain dynlibs, which are compiled for x86_64 instead.

We need to fix the Github action workflow building these wheels and fix `meson.build`.

See also #149.