### PR TITLE
Use meson-python rather than mesonpep517 as build back-end

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,7 @@ project(
     default_options: [
         'warning_level=2'
     ],
-    meson_version: '>=0.63.0'
+    meson_version: '>=0.64.0'
 )
 
 cpp = meson.get_compiler('cpp')
@@ -75,7 +75,7 @@ threads_dep = dependency('threads', required: alsa_support or jack_support)
 have_semaphore = cpp.has_header('semaphore.h')
 
 pymod = import('python')
-python = pymod.find_installation(get_option('python'), required: true)
+python = pymod.find_installation(get_option('python'), required: true, pure: false)
 
 # Generate _rtmidi extension source
 subdir('src')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [build-system]
-# https://thiblahute.gitlab.io/mesonpep517/
-build-backend = "mesonpep517.buildapi"
+build-backend = "mesonpy"
 requires = [
     "cython",
     "wheel",
-    "mesonpep517 @ git+https://gitlab.com/SpotlightKid/mesonpep517.git@rtmidi",
+    "meson-python",
     "ninja"
 ]
 
 [project]
+name = "python-rtmidi"
 description = "A Python binding for the RtMidi C++ library implemented using Cython."
 authors = [
     { name="Christopher Arndt", email="info@chrisarndt.de" },
@@ -42,12 +42,11 @@ keywords = [
     "rtmidi",
 ]
 
-[tool.mesonpep517.metadata]
-meson-python-option-name = "python"
-meson-options = [
+[tool.meson-python.args]
+setup = [
     "-Dwheel=true",
     "-Dverbose=false",
-    "--buildtype=plain"
+    "-Dbuildtype=plain"
 ]
 
 [project.license]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,8 @@ keywords = [
     "music",
     "rtmidi",
 ]
+
+[tool.mesonpep517.metadata]
 meson-python-option-name = "python"
 meson-options = [
     "-Dwheel=true",

--- a/rtmidi/meson.build
+++ b/rtmidi/meson.build
@@ -81,6 +81,5 @@ python_sources = files([
 python.install_sources(
     python_sources,
     version_py,
-    pure: true,
     subdir: 'rtmidi',
 )


### PR DESCRIPTION
mesonpep517 development appears to have stalled, with no new releases since over two years ago and no repository activity for over one year. A bit of a pity really, seeing as it actually predated meson-python by quite a while - but on the other hand, the latter IS now considered the standard PEP517 build back-end by Meson upstream.

Fortunately, switching between the two has turned out to be quite simple.