### PR TITLE
Use meson-python rather than mesonpep517 as build back-end (v2)

### DIFF
--- a/.github/workflows/pr_to_master.yml
+++ b/.github/workflows/pr_to_master.yml
@@ -50,6 +50,9 @@ jobs:
 
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.13
+      env:
+        # Skip trying to test arm64 builds on Intel Macs
+        CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
 
     - name: Upload wheels
       uses: actions/upload-artifact@v3

--- a/.github/workflows/pr_to_master.yml
+++ b/.github/workflows/pr_to_master.yml
@@ -27,6 +27,11 @@ jobs:
    - name: Check metadata
      run: pipx run twine check --strict dist/*
 
+   - name: Upload sdist
+     uses: actions/upload-artifact@v3
+     with:
+       path: dist/*.tar.gz
+
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -44,7 +49,12 @@ jobs:
       if: matrix.os == 'windows-latest'
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.12.3
+      uses: pypa/cibuildwheel@v2.13
+
+    - name: Upload wheels
+      uses: actions/upload-artifact@v3
+      with:
+        path: wheelhouse/*.whl
 
   build_arch_wheels:
    name: Build wheels on Linux ${{ matrix.arch }}
@@ -62,7 +72,8 @@ jobs:
      with:
        platforms: all
 
-   - uses: pypa/cibuildwheel@v2.12.3
+   - name: Build wheels
+     uses: pypa/cibuildwheel@v2.13
      env:
        CIBW_ARCHS: ${{ matrix.arch }}
 
@@ -70,3 +81,7 @@ jobs:
      run: git diff --exit-code
      shell: bash
 
+   - name: Upload wheels
+     uses: actions/upload-artifact@v3
+     with:
+       path: wheelhouse/*.whl

--- a/.github/workflows/push_to_master.yml
+++ b/.github/workflows/push_to_master.yml
@@ -27,7 +27,8 @@ jobs:
    - name: Check metadata
      run: pipx run twine check --strict dist/*
 
-   - uses: actions/upload-artifact@v3
+   - name: Upload sdist
+     uses: actions/upload-artifact@v3
      with:
        path: dist/*.tar.gz
 
@@ -48,7 +49,7 @@ jobs:
       if: matrix.os == 'windows-latest'
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.12.3
+      uses: pypa/cibuildwheel@v2.13
 
     - uses: actions/upload-artifact@v3
       with:
@@ -70,7 +71,8 @@ jobs:
      with:
        platforms: all
 
-   - uses: pypa/cibuildwheel@v2.12.3
+   - name: Build wheels
+     uses: pypa/cibuildwheel@v2.13
      env:
        CIBW_ARCHS: ${{ matrix.arch }}
 

--- a/.github/workflows/push_to_master.yml
+++ b/.github/workflows/push_to_master.yml
@@ -50,6 +50,9 @@ jobs:
 
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.13
+      env:
+        # Skip trying to test arm64 builds on Intel Macs
+        CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
 
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,8 @@ jobs:
    - name: Check metadata
      run: pipx run twine check --strict dist/*
 
-   - uses: actions/upload-artifact@v3
+   - name: Upload sdist
+     uses: actions/upload-artifact@v3
      with:
        path: dist/*.tar.gz
 
@@ -51,9 +52,10 @@ jobs:
       if: matrix.os == 'windows-latest'
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.12.3
+      uses: pypa/cibuildwheel@v2.13
 
-    - uses: actions/upload-artifact@v3
+    - name: Upload wheels
+      uses: actions/upload-artifact@v3
       with:
         path: wheelhouse/*.whl
 
@@ -73,7 +75,8 @@ jobs:
      with:
        platforms: all
 
-   - uses: pypa/cibuildwheel@v2.12.3
+   - name: Build wheels
+     uses: pypa/cibuildwheel@v2.13
      env:
        CIBW_ARCHS: ${{ matrix.arch }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,9 @@ jobs:
 
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.13
+      env:
+        # Skip trying to test arm64 builds on Intel Macs
+        CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
 
     - name: Upload wheels
       uses: actions/upload-artifact@v3

--- a/meson.build
+++ b/meson.build
@@ -30,7 +30,7 @@ jack_not_found = jack_dep.found() ? false : true
 
 ## From https://github.com/numpy/numpy/blob/main/numpy/meson.build
 # Platform dependent config
-if host_machine.system() == 'windows'
+if host_machine.system().to_lower() == 'windows'
     # WINDOWS
     if cpp.get_id() == 'gcc'
         # For mingw-w64, link statically against the UCRT.
@@ -50,7 +50,7 @@ if host_machine.system() == 'windows'
     # API
     winmm_dep = cpp.find_library('winmm', required: jack_not_found)
     alsa_dep = disabler()
-elif host_machine.system() == 'darwin'
+elif host_machine.system().to_lower() == 'darwin'
     # OSX
 
     # Enable c++11 support

--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,7 @@ project(
     default_options: [
         'warning_level=2'
     ],
-    meson_version: '>=0.63.0'
+    meson_version: '>=0.64.0'
 )
 
 cpp = meson.get_compiler('cpp')
@@ -75,7 +75,7 @@ threads_dep = dependency('threads', required: alsa_support or jack_support)
 have_semaphore = cpp.has_header('semaphore.h')
 
 pymod = import('python')
-python = pymod.find_installation(get_option('python'), required: true)
+python = pymod.find_installation(get_option('python'), required: true, pure: false)
 
 # Generate _rtmidi extension source
 subdir('src')

--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,8 @@ project(
     meson_version: '>=0.64.0'
 )
 
+message('Host machine system:', host_machine.system())
+
 cpp = meson.get_compiler('cpp')
 
 # Jack API (portable)

--- a/meson.build
+++ b/meson.build
@@ -47,6 +47,7 @@ if host_machine.system() == 'windows'
 
     # API
     winmm_dep = cpp.find_library('winmm', required: jack_not_found)
+    alsa_dep = disabler()
 elif host_machine.system() == 'darwin'
     # OSX
 
@@ -59,6 +60,7 @@ elif host_machine.system() == 'darwin'
         modules: ['coreaudio', 'coremidi', 'foundation'],
         required: jack_not_found
     )
+    alsa_dep = disabler()
 else
     # LINUX
 

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,8 @@ project(
     version: '1.5.2',
     license: 'MIT',
     default_options: [
-        'warning_level=2'
+        'warning_level=2',
+        'cpp_std=c++11'
     ],
     meson_version: '>=0.64.0'
 )
@@ -52,9 +53,6 @@ if host_machine.system().to_lower() == 'windows'
     alsa_dep = disabler()
 elif host_machine.system().to_lower() == 'darwin'
     # OSX
-
-    # Enable c++11 support
-    add_project_arguments('-std=c++11', language: ['cpp'])
 
     # API
     coremidi_dep = dependency(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ before-all = [
     "curl -o jack2-1.9.22.tar.gz https://codeload.github.com/jackaudio/jack2/tar.gz/refs/tags/v1.9.22",
     "tar -xzf jack2-1.9.22.tar.gz",
     "cd jack2-1.9.22",
-    "python3 waf configure --prefix=/usr --autostart=none --classic",
+    "python3 waf configure --prefix=/usr --autostart=none --classic --pkgconfigdir=/usr/lib64/pkgconfig",
     "python3 waf build",
     "python3 waf install",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,6 @@ build = "cp3{8,9,10,11}-manylinux*"
 archs = ["auto64"]
 before-all = [
     "dnf -y install alsa-lib-devel alsa-utils",
-    "pipx install ninja",
     "curl -o jack2-1.9.21.tar.gz https://codeload.github.com/jackaudio/jack2/tar.gz/refs/tags/v1.9.21",
     "tar -xzf jack2-1.9.21.tar.gz",
     "cd jack2-1.9.21",
@@ -109,9 +108,6 @@ before-all = [
 build = "cp3{8,9,10,11}-macosx*"
 archs = ["x86_64", "arm64"]
 environment = { MACOSX_DEPLOYMENT_TARGET = "10.14" }
-before-all = [
-    "pipx install ninja",
-]
 
 [tool.cibuildwheel.windows]
 build = "cp3{8,9,10,11}-win*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,6 @@ before-all = [
 [tool.cibuildwheel.macos]
 build = "cp3{8,9,10,11}-macosx*"
 archs = ["x86_64", "arm64"]
-environment = { MACOSX_DEPLOYMENT_TARGET = "10.14" }
 
 [tool.cibuildwheel.windows]
 build = "cp3{8,9,10,11}-win*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,9 +96,9 @@ build = "cp3{8,9,10,11}-manylinux*"
 archs = ["auto64"]
 before-all = [
     "dnf -y install alsa-lib-devel alsa-utils",
-    "curl -o jack2-1.9.21.tar.gz https://codeload.github.com/jackaudio/jack2/tar.gz/refs/tags/v1.9.21",
-    "tar -xzf jack2-1.9.21.tar.gz",
-    "cd jack2-1.9.21",
+    "curl -o jack2-1.9.22.tar.gz https://codeload.github.com/jackaudio/jack2/tar.gz/refs/tags/v1.9.22",
+    "tar -xzf jack2-1.9.22.tar.gz",
+    "cd jack2-1.9.22",
     "python3 waf configure --prefix=/usr --autostart=none --classic",
     "python3 waf build",
     "python3 waf install",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [build-system]
-# https://thiblahute.gitlab.io/mesonpep517/
-build-backend = "mesonpep517.buildapi"
+build-backend = "mesonpy"
 requires = [
     "cython",
     "wheel",
-    "mesonpep517 @ git+https://gitlab.com/SpotlightKid/mesonpep517.git@rtmidi",
+    "meson-python",
     "ninja"
 ]
 
 [project]
+name = "python-rtmidi"
 description = "A Python binding for the RtMidi C++ library implemented using Cython."
 authors = [
     { name="Christopher Arndt", email="info@chrisarndt.de" },
@@ -41,11 +41,12 @@ keywords = [
     "music",
     "rtmidi",
 ]
-meson-python-option-name = "python"
-meson-options = [
+
+[tool.meson-python.args]
+setup = [
     "-Dwheel=true",
     "-Dverbose=false",
-    "--buildtype=plain"
+    "-Dbuildtype=plain"
 ]
 
 [project.license]

--- a/rtmidi/meson.build
+++ b/rtmidi/meson.build
@@ -81,6 +81,5 @@ python_sources = files([
 python.install_sources(
     python_sources,
     version_py,
-    pure: true,
     subdir: 'rtmidi',
 )


### PR DESCRIPTION
meson-python is actively maintained and handles cross-compilation without much hassle.