### PR TITLE
fix: compare against lower case host system name *really* everywhere

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -69,9 +69,9 @@ else
 endif # Platform detection
 
 jack_support = jack_dep.found() and get_option('jack')
-alsa_support = host_machine.system() == 'linux' and alsa_dep.found() and get_option('alsa')
-coremidi_support = host_machine.system() == 'darwin' and coremidi_dep.found() and get_option('coremidi')
-winmm_support = host_machine.system() == 'windows' and winmm_dep.found() and get_option('winmm')
+alsa_support = host_machine.system().to_lower() == 'linux' and alsa_dep.found() and get_option('alsa')
+coremidi_support = host_machine.system().to_lower() == 'darwin' and coremidi_dep.found() and get_option('coremidi')
+winmm_support = host_machine.system().to_lower() == 'windows' and winmm_dep.found() and get_option('winmm')
 
 threads_dep = dependency('threads', required: alsa_support or jack_support)
 have_semaphore = cpp.has_header('semaphore.h')


### PR DESCRIPTION
macOS arm64 binary wheels were compiled without CoreMIDI support, because host machine value is 'Darwin', not 'darwin' when cross-compiling in current version of meson-python.

Fixes: #168