### PR TITLE
fix: declare version to be dynamic in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ requires = [
 
 [project]
 name = "python-rtmidi"
+dynamic = ['version']
 description = "A Python binding for the RtMidi C++ library implemented using Cython."
 authors = [
     { name="Christopher Arndt", email="info@chrisarndt.de" },


### PR DESCRIPTION
Required since meson-python >= 0.14.0.

Fixes #176.