### PR TITLE
Revert to prior init mechanism to support pypy

### DIFF
--- a/src/_rtmidi.pyx
+++ b/src/_rtmidi.pyx
@@ -128,10 +128,10 @@ __all__ = (
     'get_compiled_api', 'get_compiled_api_by_name', 'get_rtmidi_version'
 )
 
-cdef extern from "Python.h":
-    void Py_Initialize()
+cdef extern from "py_init.h":
+    void py_init()
 
-Py_Initialize()
+py_init()
 
 # Declarations for RtMidi C++ classes and their methods we use
 

--- a/src/py_init.h
+++ b/src/py_init.h
@@ -1,0 +1,22 @@
+#include <Python.h>
+ /*
+  * This code initializes Python threads and GIL, because RtMidi calls Python
+  * from native threads.
+  *
+  * See http://permalink.gmane.org/gmane.comp.python.cython.user/5837
+  *
+  * *PyEval_InitThreads* is a no-op since Python.37 and deprecated since
+  * Python 3.6. Now *Py_Initialize* initializes the GIL.
+  *
+  * The calls are in this separate C file instead of in the main .pyx file so
+  * that we can use pre-compiler conditionals and don't get a compiler
+  * deprecation warning on Python 3.9+ for including *PyEval_InitThreads*.
+  */
+
+ void py_init() {
+     #if !defined(PYPY_VERSION) and PY_MAJOR_VERSION >= 3 and PY_MINOR_VERSION >= 7
+         Py_Initialize();
+     #else
+         PyEval_InitThreads();
+     #endif
+ } 


### PR DESCRIPTION
During the change to meson, the ability to compile under pypy was lost.

Reverting just that change - ie restoring py_init.h and differentiating there on what to call restores compatibility with pypy