### PR TITLE
Don't add a MSVC-style flag if not using MSVC on windows

### DIFF
--- a/rtmidi/meson.build
+++ b/rtmidi/meson.build
@@ -26,7 +26,7 @@ endif
 
 if winmm_support
     defines += ['-D__WINDOWS_MM__']
-    if meson.get_compiler('cpp').get_id() != 'gcc'
+    if meson.get_compiler('cpp').get_argument_syntax() == 'msvc'
         defines += ['/EHsc']
     endif
     dependencies += [winmm_dep]


### PR DESCRIPTION
Currently when building on Windows, the only time an MSVC-style flag *isn't* defined is if the build system is using `gcc`. This causes problems when building with almost anything that isn't `gcc` or `msvc`, i.e. `clang`.

With this PR, the MSVC-style flag is only defined when `msvc` (or something that accepts MSVC-style syntax) is being used.

For expected return values of the `get_argument_syntax()` method, see https://mesonbuild.com/Reference-tables.html#compiler-ids

The method requires `meson >= 0.49`, but as `python-rtmidi` itself (currently) requires `meson >= 0.64`, this should be acceptable.