### PR TITLE
feat: add Python 3.13 support

### DIFF
--- a/.github/workflows/pr_to_master.yml
+++ b/.github/workflows/pr_to_master.yml
@@ -10,27 +10,28 @@ jobs:
     name: Build sdist
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
 
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
+      - name: Install ninja
+        run: pipx install ninja
 
-    - name: Install ninja
-      run: pipx install ninja
+      - name: Install alsa deps
+        run: sudo apt-get install libasound2-dev
 
-    - name: Install alsa deps
-      run: sudo apt-get install libasound2-dev
+      - name: Build sdist
+        run: pipx run build --sdist
 
-    - name: Build sdist
-      run: pipx run build --sdist
+      - name: Check metadata
+        run: pipx run twine check --strict dist/*
 
-    - name: Check metadata
-      run: pipx run twine check --strict dist/*
-
-    - name: Upload sdist
-      uses: actions/upload-artifact@v4
-      with:
-        path: dist/*.tar.gz
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+          compression-level: 0
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
@@ -38,53 +39,28 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest]
     steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
 
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
+      - uses: ilammy/msvc-dev-cmd@v1
+        if: matrix.os == 'windows-latest'
 
-    - uses: ilammy/msvc-dev-cmd@v1
-      if: matrix.os == 'windows-latest'
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.22
+        env:
+          # Skip trying to test arm64 builds on Intel Macs
+          CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
 
-    - name: Build wheels
-      uses: pypa/cibuildwheel@v2.21
-      env:
-        # Skip trying to test arm64 builds on Intel Macs
-        CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
+      - name: Verify clean directory
+        run: git diff --exit-code
+        shell: bash
 
-    - name: Upload wheels
-      uses: actions/upload-artifact@v4
-      with:
-        path: wheelhouse/*.whl
-
-  build_arch_wheels:
-    name: Build wheels on Linux ${{ matrix.arch }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [aarch64]
-    steps:
-
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-
-    - uses: docker/setup-qemu-action@v3
-      with:
-        platforms: all
-
-    - name: Build wheels
-      uses: pypa/cibuildwheel@v2.21
-      env:
-        CIBW_ARCHS: ${{ matrix.arch }}
-
-    - name: Verify clean directory
-      run: git diff --exit-code
-      shell: bash
-
-    - name: Upload wheels
-      uses: actions/upload-artifact@v4
-      with:
-        path: wheelhouse/*.whl
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: bdist-${{ matrix.os }}
+          path: wheelhouse/*.whl
+          compression-level: 0

--- a/.github/workflows/pr_to_master.yml
+++ b/.github/workflows/pr_to_master.yml
@@ -30,9 +30,7 @@ jobs:
     - name: Upload sdist
       uses: actions/upload-artifact@v4
       with:
-        name: sdist
         path: dist/*.tar.gz
-        compression-level: 0
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
@@ -40,7 +38,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
 
     - uses: actions/checkout@v4
@@ -51,10 +49,36 @@ jobs:
       if: matrix.os == 'windows-latest'
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.22
+      uses: pypa/cibuildwheel@v2.21
       env:
         # Skip trying to test arm64 builds on Intel Macs
         CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
+
+    - name: Upload wheels
+      uses: actions/upload-artifact@v4
+      with:
+        path: wheelhouse/*.whl
+
+  build_arch_wheels:
+    name: Build wheels on Linux ${{ matrix.arch }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [aarch64]
+    steps:
+
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - uses: docker/setup-qemu-action@v3
+      with:
+        platforms: all
+
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.21
+      env:
+        CIBW_ARCHS: ${{ matrix.arch }}
 
     - name: Verify clean directory
       run: git diff --exit-code
@@ -63,6 +87,4 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: bdist-${{ matrix.os }}
         path: wheelhouse/*.whl
-        compression-level: 0

--- a/.github/workflows/push_to_master.yml
+++ b/.github/workflows/push_to_master.yml
@@ -10,27 +10,28 @@ jobs:
     name: Build sdist
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
 
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
+      - name: Install ninja
+        run: pipx install ninja
 
-    - name: Install ninja
-      run: pipx install ninja
+      - name: Install alsa deps
+        run: sudo apt-get install libasound2-dev
 
-    - name: Install alsa deps
-      run: sudo apt-get install libasound2-dev
+      - name: Build sdist
+        run: pipx run build --sdist
 
-    - name: Build sdist
-      run: pipx run build --sdist
+      - name: Check metadata
+        run: pipx run twine check --strict dist/*
 
-    - name: Check metadata
-      run: pipx run twine check --strict dist/*
-
-    - name: Upload sdist
-      uses: actions/upload-artifact@v4
-      with:
-        path: dist/*.tar.gz
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+          compression-level: 0
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
@@ -38,76 +39,48 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest]
     steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
 
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
+      - uses: ilammy/msvc-dev-cmd@v1
+        if: matrix.os == 'windows-latest'
 
-    - uses: ilammy/msvc-dev-cmd@v1
-      if: matrix.os == 'windows-latest'
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.22
+        env:
+          # Skip trying to test arm64 builds on Intel Macs
+          CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
 
-    - name: Build wheels
-      uses: pypa/cibuildwheel@v2.21
-      env:
-        # Skip trying to test arm64 builds on Intel Macs
-        CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
+      - name: Verify clean directory
+        run: git diff --exit-code
+        shell: bash
 
-    - name: Upload wheels
-      uses: actions/upload-artifact@v4
-      with:
-        path: wheelhouse/*.whl
-
-  build_arch_wheels:
-    name: Build wheels on Linux ${{ matrix.arch }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [aarch64]
-    steps:
-
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-
-    - uses: docker/setup-qemu-action@v3
-      with:
-        platforms: all
-
-    - name: Build wheels
-      uses: pypa/cibuildwheel@v2.21
-      env:
-        CIBW_ARCHS: ${{ matrix.arch }}
-
-    - name: Verify clean directory
-      run: git diff --exit-code
-      shell: bash
-
-    - name: Upload wheels
-      uses: actions/upload-artifact@v4
-      with:
-        path: wheelhouse/*.whl
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: bdist-${{ matrix.os }}
+          path: wheelhouse/*.whl
+          compression-level: 0
 
   upload_pypi:
-    needs: [build_arch_wheels, build_wheels, build_sdist]
+    needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     environment: PyPI release
     if: github.ref == 'refs/heads/develop'
     steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
 
-    - uses: actions/download-artifact@v4
-      with:
-        # unpacks default artifact into dist/
-        # if `name: artifact` is omitted, the action will create extra parent dir
-        name: artifact
-        path: dist
-
-    - name: Publish distribution to Test PyPI
-      uses: pypa/gh-action-pypi-publish@v1.8.6
-      with:
-        skip_existing: true
-        user: __token__
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
-        verify-metadata: false
+      - name: Publish distribution to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip_existing: true
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+          verify-metadata: false

--- a/.github/workflows/push_to_master.yml
+++ b/.github/workflows/push_to_master.yml
@@ -30,9 +30,7 @@ jobs:
     - name: Upload sdist
       uses: actions/upload-artifact@v4
       with:
-        name: sdist
         path: dist/*.tar.gz
-        compression-level: 0
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
@@ -40,7 +38,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
 
     - uses: actions/checkout@v4
@@ -51,10 +49,36 @@ jobs:
       if: matrix.os == 'windows-latest'
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.22
+      uses: pypa/cibuildwheel@v2.21
       env:
         # Skip trying to test arm64 builds on Intel Macs
         CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
+
+    - name: Upload wheels
+      uses: actions/upload-artifact@v4
+      with:
+        path: wheelhouse/*.whl
+
+  build_arch_wheels:
+    name: Build wheels on Linux ${{ matrix.arch }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [aarch64]
+    steps:
+
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - uses: docker/setup-qemu-action@v3
+      with:
+        platforms: all
+
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.21
+      env:
+        CIBW_ARCHS: ${{ matrix.arch }}
 
     - name: Verify clean directory
       run: git diff --exit-code
@@ -63,12 +87,10 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: bdist-${{ matrix.os }}
         path: wheelhouse/*.whl
-        compression-level: 0
 
   upload_pypi:
-    needs: [build_wheels, build_sdist]
+    needs: [build_arch_wheels, build_wheels, build_sdist]
     runs-on: ubuntu-latest
     environment: PyPI release
     if: github.ref == 'refs/heads/develop'
@@ -76,11 +98,13 @@ jobs:
 
     - uses: actions/download-artifact@v4
       with:
+        # unpacks default artifact into dist/
+        # if `name: artifact` is omitted, the action will create extra parent dir
+        name: artifact
         path: dist
-        merge-multiple: true
 
     - name: Publish distribution to Test PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@v1.8.6
       with:
         skip_existing: true
         user: __token__

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,99 +14,73 @@ jobs:
     name: Build sdist
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
 
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
+      - name: Install ninja
+        run: pipx install ninja
 
-    - name: Install ninja
-      run: pipx install ninja
+      - name: Install alsa deps
+        run: sudo apt-get install libasound2-dev
 
-    - name: Install alsa deps
-      run: sudo apt-get install libasound2-dev
+      - name: Build sdist
+        run: pipx run build --sdist
 
-    - name: Build sdist
-      run: pipx run build --sdist
+      - name: Check metadata
+        run: pipx run twine check --strict dist/*
 
-    - name: Check metadata
-      run: pipx run twine check --strict dist/*
-
-    - name: Upload sdist
-      uses: actions/upload-artifact@v4
-      with:
-        path: dist/*.tar.gz
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+          compression-level: 0
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest]
     steps:
+      - uses: actions/checkout@v
+        with:
+          submodules: true
 
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
+      - uses: ilammy/msvc-dev-cmd@v1
+        if: matrix.os == 'windows-latest'
 
-    - uses: ilammy/msvc-dev-cmd@v1
-      if: matrix.os == 'windows-latest'
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.22
+        env:
+          # Skip trying to test arm64 builds on Intel Macs
+          CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
 
-    - name: Build wheels
-      uses: pypa/cibuildwheel@v2.21
-      env:
-        # Skip trying to test arm64 builds on Intel Macs
-        CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
+      - name: Verify clean directory
+        run: git diff --exit-code
+        shell: bash
 
-    - name: Upload wheels
-      uses: actions/upload-artifact@v4
-      with:
-        path: wheelhouse/*.whl
-
-  build_arch_wheels:
-    name: Build wheels on Linux ${{ matrix.arch }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [aarch64]
-    steps:
-
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-
-    - uses: docker/setup-qemu-action@v3
-      with:
-        platforms: all
-
-    - name: Build wheels
-      uses: pypa/cibuildwheel@v2.21
-      env:
-        CIBW_ARCHS: ${{ matrix.arch }}
-
-    - name: Verify clean directory
-      run: git diff --exit-code
-      shell: bash
-
-    - name: Upload wheels
-      uses: actions/upload-artifact@v4
-      with:
-        path: wheelhouse/*.whl
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: bdist-${{ matrix.os }}
+          path: wheelhouse/*.whl
+          compression-level: 0
 
   upload_pypi:
-    needs: [build_arch_wheels, build_wheels, build_sdist]
+    needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     environment: PyPI release
     steps:
-    - uses: actions/download-artifact@v4
-      with:
-        # unpacks default artifact into dist/
-        # if `name: artifact` is omitted, the action will create extra parent dir
-        name: artifact
-        path: dist
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
 
-    - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.8.6
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
-        verify-metadata: false
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          verify-metadata: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,19 +34,17 @@ jobs:
     - name: Upload sdist
       uses: actions/upload-artifact@v4
       with:
-        name: sdist
         path: dist/*.tar.gz
-        compression-level: 0
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
 
-    - uses: actions/checkout@v
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -54,10 +52,36 @@ jobs:
       if: matrix.os == 'windows-latest'
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.22
+      uses: pypa/cibuildwheel@v2.21
       env:
         # Skip trying to test arm64 builds on Intel Macs
         CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
+
+    - name: Upload wheels
+      uses: actions/upload-artifact@v4
+      with:
+        path: wheelhouse/*.whl
+
+  build_arch_wheels:
+    name: Build wheels on Linux ${{ matrix.arch }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [aarch64]
+    steps:
+
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - uses: docker/setup-qemu-action@v3
+      with:
+        platforms: all
+
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.21
+      env:
+        CIBW_ARCHS: ${{ matrix.arch }}
 
     - name: Verify clean directory
       run: git diff --exit-code
@@ -66,22 +90,22 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: bdist-${{ matrix.os }}
         path: wheelhouse/*.whl
-        compression-level: 0
 
   upload_pypi:
-    needs: [build_wheels, build_sdist]
+    needs: [build_arch_wheels, build_wheels, build_sdist]
     runs-on: ubuntu-latest
     environment: PyPI release
     steps:
     - uses: actions/download-artifact@v4
       with:
+        # unpacks default artifact into dist/
+        # if `name: artifact` is omitted, the action will create extra parent dir
+        name: artifact
         path: dist
-        merge-multiple: true
 
     - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@v1.8.6
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Python bytecode
 *.py[cod]
 __pycache__
+.python-version
+
+# UV
+uv.lock
 
 # Cython output
 src/_rtmidi.cpp
@@ -51,3 +55,6 @@ rtmidi/version.py
 
 # Geany project
 python-rtmidi.geany
+
+# Darwin
+.DS_Store

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = "mesonpy"
 requires = [
-    "cython",
+    "cython>=3.0",
     "wheel",
     "meson-python",
     "ninja"
@@ -15,7 +15,7 @@ authors = [
     { name="Christopher Arndt", email="info@chrisarndt.de" },
 ]
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: MacOS X",
@@ -28,6 +28,7 @@ classifiers = [
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -63,6 +64,7 @@ file = "LICENSE.md"
 [tool.black]
 line-length = 99
 target-version = [
+    "py38",
     "py39",
     "py310",
     "py311",
@@ -90,17 +92,17 @@ markers = [
 [tool.cibuildwheel]
 # Switch to using build
 build-frontend = "build"
+skip = "pp*"
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
 # Run the package tests using `pytest`
 test-requires = "pytest"
 test-command = "pytest -v -m ci {package}/tests"
 
+# Install system library
 [tool.cibuildwheel.linux]
-build = ["cp3{9,10,11,12,13}-manylinux*", "pp3{9,10,11}-manylinux*"]
+build = "cp3{8,9,10,11,12,13}-manylinux*"
 archs = ["auto64"]
-enable = ["pypy"]
-# Install system libraries
 before-all = [
     "dnf -y install alsa-lib-devel alsa-utils",
     "curl -o jack2-1.9.22.tar.gz https://codeload.github.com/jackaudio/jack2/tar.gz/refs/tags/v1.9.22",
@@ -113,9 +115,9 @@ before-all = [
 repair-wheel-command = "auditwheel repair --exclude libasound.so.2 --lib-sdir . -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.macos]
-build = "cp3{9,10,11,12,13}-macosx*"
+build = "cp3{8,9,10,11,12,13}-macosx*"
 archs = ["x86_64", "arm64"]
 
 [tool.cibuildwheel.windows]
-build = "cp3{9,10,11,12,13}-win*"
+build = "cp3{8,9,10,11,12,13}-win*"
 archs = ["AMD64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = "mesonpy"
 requires = [
-    "cython>=3.0",
+    "cython",
     "wheel",
     "meson-python",
     "ninja"
@@ -15,7 +15,7 @@ authors = [
     { name="Christopher Arndt", email="info@chrisarndt.de" },
 ]
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: MacOS X",
@@ -28,7 +28,6 @@ classifiers = [
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -64,7 +63,6 @@ file = "LICENSE.md"
 [tool.black]
 line-length = 99
 target-version = [
-    "py38",
     "py39",
     "py310",
     "py311",
@@ -92,7 +90,6 @@ markers = [
 [tool.cibuildwheel]
 # Switch to using build
 build-frontend = "build"
-skip = "pp*"
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
 # Run the package tests using `pytest`
@@ -101,8 +98,10 @@ test-command = "pytest -v -m ci {package}/tests"
 
 # Install system library
 [tool.cibuildwheel.linux]
-build = "cp3{8,9,10,11,12,13}-manylinux*"
+build = ["cp3{9,10,11,12,13}-manylinux*", "pp3{9,10,11}-manylinux*"]
 archs = ["auto64"]
+enable = ["pypy"]
+# Install system libraries
 before-all = [
     "dnf -y install alsa-lib-devel alsa-utils",
     "curl -o jack2-1.9.22.tar.gz https://codeload.github.com/jackaudio/jack2/tar.gz/refs/tags/v1.9.22",
@@ -115,9 +114,9 @@ before-all = [
 repair-wheel-command = "auditwheel repair --exclude libasound.so.2 --lib-sdir . -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.macos]
-build = "cp3{8,9,10,11,12,13}-macosx*"
+build = "cp3{9,10,11,12,13}-macosx*"
 archs = ["x86_64", "arm64"]
 
 [tool.cibuildwheel.windows]
-build = "cp3{8,9,10,11,12,13}-win*"
+build = "cp3{9,10,11,12,13}-win*"
 archs = ["AMD64"]


### PR DESCRIPTION
- Require Cython >= 3.0 in build system (mandatory for Python 3.13)
- Add cp313 to cibuildwheel build patterns on all platforms
- Add Python 3.13 classifier in pyproject.toml
- Bump cibuildwheel to v2.21 (3.13 support added in v2.17)
- Update GitHub Actions to v4 (checkout, upload/download-artifact)
- Update docker/setup-qemu-action to v3
- Replace deprecated ubuntu-20.04 runner with ubuntu-latest