### PR TITLE
Fix/coremidi test failures

### DIFF
--- a/.github/workflows/push_to_master.yml
+++ b/.github/workflows/push_to_master.yml
@@ -4,36 +4,34 @@ on:
   push:
     branches:
       - master
-  workflow_dispatch:
 
 jobs:
   build_sdist:
     name: Build sdist
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
 
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
+      - name: Install ninja
+        run: pipx install ninja
 
-    - name: Install ninja
-      run: pipx install ninja
+      - name: Install alsa deps
+        run: sudo apt-get install libasound2-dev
 
-    - name: Install alsa deps
-      run: sudo apt-get install libasound2-dev
+      - name: Build sdist
+        run: pipx run build --sdist
 
-    - name: Build sdist
-      run: pipx run build --sdist
+      - name: Check metadata
+        run: pipx run twine check --strict dist/*
 
-    - name: Check metadata
-      run: pipx run twine check --strict dist/*
-
-    - name: Upload sdist
-      uses: actions/upload-artifact@v4
-      with:
-        name: sdist
-        path: dist/*.tar.gz
-        compression-level: 0
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+          compression-level: 0
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
@@ -43,30 +41,29 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest]
     steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
 
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
+      - uses: ilammy/msvc-dev-cmd@v1
+        if: matrix.os == 'windows-latest'
 
-    - uses: ilammy/msvc-dev-cmd@v1
-      if: matrix.os == 'windows-latest'
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.22
+        env:
+          # Skip trying to test arm64 builds on Intel Macs
+          CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
 
-    - name: Build wheels
-      uses: pypa/cibuildwheel@v2.22
-      env:
-        # Skip trying to test arm64 builds on Intel Macs
-        CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
+      - name: Verify clean directory
+        run: git diff --exit-code
+        shell: bash
 
-    - name: Verify clean directory
-      run: git diff --exit-code
-      shell: bash
-
-    - name: Upload wheels
-      uses: actions/upload-artifact@v4
-      with:
-        name: bdist-${{ matrix.os }}
-        path: wheelhouse/*.whl
-        compression-level: 0
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: bdist-${{ matrix.os }}
+          path: wheelhouse/*.whl
+          compression-level: 0
 
   upload_pypi:
     needs: [build_wheels, build_sdist]
@@ -74,17 +71,16 @@ jobs:
     environment: PyPI release
     if: github.ref == 'refs/heads/develop'
     steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
 
-    - uses: actions/download-artifact@v4
-      with:
-        path: dist
-        merge-multiple: true
-
-    - name: Publish distribution to Test PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        skip_existing: true
-        user: __token__
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
-        verify-metadata: false
+      - name: Publish distribution to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip_existing: true
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+          verify-metadata: false

--- a/.github/workflows/push_to_master.yml
+++ b/.github/workflows/push_to_master.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   build_sdist:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Python bytecode
 *.py[cod]
 __pycache__
+.python-version
+
+# UV
+uv.lock
 
 # Cython output
 src/_rtmidi.cpp
@@ -51,3 +55,6 @@ rtmidi/version.py
 
 # Geany project
 python-rtmidi.geany
+
+# Darwin
+.DS_Store

--- a/src/_rtmidi.pyx
+++ b/src/_rtmidi.pyx
@@ -320,10 +320,11 @@ class NoDevicesError(SystemError):
     type = ERR_NO_DEVICES_FOUND
 
 
-class UnsupportedOperationError(RtMidiError, RuntimeError):
+class UnsupportedOperationError(RtMidiError, NotImplementedError):
     """Raised if a method is not supported by the low-level API.
 
-    Also derives from ``RuntimeError``.
+    Also derives from ``NotImplementedError`` (which itself is a subclass of
+    ``RuntimeError``), so existing code catching ``RuntimeError`` is unaffected.
 
     """
     pass

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -22,10 +22,10 @@ class TestDelete(unittest.TestCase):
         print("output ports initially:")
         print(ports_init)
 
-        if midiin_ports:
-            self.midiin.open_port(0)
-        else:
-            self.midiin.open_virtual_port("My virtual output")
+        # Always use a virtual port so a new port is guaranteed to appear in the list.
+        # Opening a real port does not add to the port count, which breaks the +1 assertion
+        # on macOS where system MIDI ports already exist.
+        self.midiin.open_virtual_port("My virtual output")
 
         ports_before = self.midiout.get_ports()
 
@@ -50,10 +50,10 @@ class TestDelete(unittest.TestCase):
         print("Input ports initially:")
         print(ports_init)
 
-        if midiout_ports:
-            self.midiout.open_port(0)
-        else:
-            self.midiout.open_virtual_port("My virtual output")
+        # Always use a virtual port so a new port is guaranteed to appear in the list.
+        # Opening a real port does not add to the port count, which breaks the +1 assertion
+        # on macOS where system MIDI ports already exist.
+        self.midiout.open_virtual_port("My virtual output")
 
         ports_before = self.midiin.get_ports()
 


### PR DESCRIPTION
- Always use `open_virtual_port` in `test_delete` tests to fix false failures on macOS, where system MIDI ports already exist and `open_port(0)` does not add a new port to the port count
-  Make `UnsupportedOperationError` a subclass of `NotImplementedError` so `assertRaises(NotImplementedError)` passes in `CoreMIDITestCase` — backward compatible since `NotImplementedError` is itself a subclass of `RuntimeError